### PR TITLE
Domain update

### DIFF
--- a/app/public/service-worker.js
+++ b/app/public/service-worker.js
@@ -1,6 +1,6 @@
 /// <reference lib="webworker" />
 
-const CACHE_NAME = "Kargo_v1.0.0";
+const CACHE_NAME = "Kargo_v1.0.1";
 const CORE_ASSETS = [
   "/",
   "/offline",

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
     title: "Kargo",
     description:
       "Kargo lets you deploy containerized applications with full flexibility — AI-powered setup, secure infrastructure, and Kubernetes-native scaling, all from a powerful web interface.",
-    url: "https://kargo.upayan.dev",
+    url: "https://kargo.dscvit.com",
     siteName: "Kargo",
     images: [
       {
@@ -62,9 +62,9 @@ export const metadata: Metadata = {
     address: false,
     email: false,
   },
-  metadataBase: new URL("https://kargo.upayan.dev"),
+  metadataBase: new URL("https://kargo.dscvit.com"),
   alternates: {
-    canonical: "https://kargo.upayan.dev",
+    canonical: "https://kargo.dscvit.com",
     types: {
       "application/rss+xml": "/feed.xml",
       "application/atom+xml": "/feed.atom",
@@ -98,7 +98,7 @@ export const metadata: Metadata = {
   authors: [
     {
       name: "Upayan Mazumder",
-      url: "https://upayan.dev",
+      url: "https://dscvit.com",
     },
   ],
   applicationName: "Kargo",

--- a/app/src/lib/metadata.ts
+++ b/app/src/lib/metadata.ts
@@ -15,7 +15,7 @@ export function generatePageMetadata({
   image = "/og-image.png",
   imageAlt,
 }: PageMetadataOptions): Metadata {
-  const url = `https://kargo.upayan.dev${path}`;
+  const url = `https://kargo.dscvit.com${path}`;
   const fullTitle = path === "" ? title : `${title} - Kargo`;
   const altText = imageAlt || `${title} - Kargo`;
 

--- a/app/src/utils/api.ts
+++ b/app/src/utils/api.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const baseURL =
-  process.env.NEXT_PUBLIC_API_URL || "https://api.kargo.upayan.dev";
+  process.env.NEXT_PUBLIC_API_URL || "https://api.kargo.dscvit.com";
 
 const instance = axios.create({
   baseURL,


### PR DESCRIPTION
This pull request updates all references to the old `upayan.dev` domain, switching them to the new `dscvit.com` domain throughout the codebase. These changes ensure that all metadata, API endpoints, and author URLs consistently use the new domain.

**Domain migration updates:**

* Updated all URLs in the `metadata` object within `app/src/app/layout.tsx` to use `https://kargo.dscvit.com` instead of `https://kargo.upayan.dev` [[1]](diffhunk://#diff-5b67baf22505aea33188d52dc7a36f0a902ee6843be3281ed2da639b0d5701feL26-R26) [[2]](diffhunk://#diff-5b67baf22505aea33188d52dc7a36f0a902ee6843be3281ed2da639b0d5701feL65-R67).
* Changed the author URL in the `authors` array from `https://upayan.dev` to `https://dscvit.com` in `app/src/app/layout.tsx`.
* Updated the canonical URL generation in `generatePageMetadata` to use the new domain in `app/src/lib/metadata.ts`.
* Changed the default API base URL in `app/src/utils/api.ts` to `https://api.kargo.dscvit.com`.