### PR TITLE
Improve service worker caching logic and error handling for fetch req…

### DIFF
--- a/app/public/service-worker.js
+++ b/app/public/service-worker.js
@@ -43,7 +43,7 @@ self.addEventListener('install', (event) => {
   event.waitUntil(
     caches
       .open(PRECACHE)
-      .then((cache) => cache.addAll(CORE_ASSETS))
+      .then((cache) => Promise.allSettled(CORE_ASSETS.map((asset) => cache.add(asset))))
       .then(() => self.skipWaiting())
   );
 });
@@ -62,25 +62,32 @@ self.addEventListener('activate', (event) => {
   );
 });
 
-// Helper: prune runtime cache by age and max entries
+// Runtime cache pruning
 async function pruneRuntimeCache() {
   const cache = await caches.open(RUNTIME);
   const requests = await cache.keys();
   const now = Date.now();
 
-  const entries = [];
-  for (const req of requests) {
-    const res = await cache.match(req);
-    const fetchedTime = res && res.headers.get('SW-Fetched-Time');
-    entries.push({ req, time: fetchedTime ? parseInt(fetchedTime) : 0 });
-  }
+  let entries = await Promise.all(
+    requests.map(async (req) => {
+      const res = await cache.match(req);
+      const fetchedTime = res?.headers.get('SW-Fetched-Time');
+      return { req, time: fetchedTime ? parseInt(fetchedTime) : 0 };
+    })
+  );
 
   // Remove old entries by age
-  for (const entry of entries) {
-    if (now - entry.time > RUNTIME_MAX_AGE) {
-      await cache.delete(entry.req);
-    }
-  }
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (now - entry.time > RUNTIME_MAX_AGE) {
+        await cache.delete(entry.req);
+        entry.deleted = true;
+      }
+    })
+  );
+
+  // Filter out deleted entries
+  entries = entries.filter((entry) => !entry.deleted);
 
   // Remove excess entries beyond max entries
   entries.sort((a, b) => a.time - b.time);
@@ -90,35 +97,51 @@ async function pruneRuntimeCache() {
   }
 }
 
-// Fetch
+// Fetch handler
 self.addEventListener('fetch', (event) => {
   const request = event.request;
   const url = new URL(request.url);
 
   if (request.method !== 'GET' || url.origin !== self.location.origin) return;
 
+  // Core assets: cache-first
   if (CORE_ASSETS.includes(url.pathname)) {
     event.respondWith(
       caches.match(request).then((cached) => {
         const networkFetch = fetch(request)
           .then((response) => {
-            caches.open(PRECACHE).then((cache) => cache.put(request, response.clone()));
+            if (response && response.status === 200) {
+              caches.open(PRECACHE).then((cache) => cache.put(request, response.clone()));
+            }
             return response;
           })
-          .catch(() => cached);
+          .catch((err) => {
+            console.error('Fetch failed for core asset:', request.url, err);
+            return cached || caches.match('/offline') || new Response('Service unavailable', { status: 503 });
+          });
 
         return cached || networkFetch;
       })
     );
-  } else if (request.mode === 'navigate') {
-    event.respondWith(fetch(request).catch(() => caches.match('/offline')));
-  } else {
+  }
+  // Navigation requests: network-first, fallback offline
+  else if (request.mode === 'navigate') {
     event.respondWith(
-      caches.match(request).then((cached) => {
+      fetch(request).catch((err) => {
+        console.error('Navigation fetch failed:', request.url, err);
+        return caches.match('/offline') || new Response('Offline', { status: 503 });
+      })
+    );
+  }
+  // Other runtime requests: network-first, runtime cache
+  else {
+    event.respondWith(
+      caches.match(request).then(async (cached) => {
         if (cached) return cached;
 
-        return fetch(request)
-          .then(async (response) => {
+        try {
+          const response = await fetch(request);
+          if (response && response.status === 200) {
             const cloned = response.clone();
             const headers = new Headers(cloned.headers);
             headers.set('SW-Fetched-Time', Date.now().toString());
@@ -126,9 +149,12 @@ self.addEventListener('fetch', (event) => {
             const cache = await caches.open(RUNTIME);
             await cache.put(request, modifiedResponse);
             await pruneRuntimeCache();
-            return response;
-          })
-          .catch(() => {});
+          }
+          return response;
+        } catch (err) {
+          console.error('Runtime fetch failed:', request.url, err);
+          return caches.match('/offline') || new Response('Service unavailable', { status: 503 });
+        }
       })
     );
   }
@@ -136,5 +162,5 @@ self.addEventListener('fetch', (event) => {
 
 // Skip waiting via client message
 self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'SKIP_WAITING') self.skipWaiting();
+  if (event.data?.type === 'SKIP_WAITING') self.skipWaiting();
 });

--- a/app/public/service-worker.js
+++ b/app/public/service-worker.js
@@ -2,175 +2,142 @@ const VERSION = 'v1.1.1';
 const PRECACHE = `precache-${VERSION}`;
 const RUNTIME = `runtime-${VERSION}`;
 const RUNTIME_MAX_ENTRIES = 100;
-const RUNTIME_MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days in ms
+const RUNTIME_MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 const CORE_ASSETS = [
-  '/',
-  '/offline',
-  '/manifest.webmanifest',
+  '/', '/offline', '/manifest.webmanifest',
   '/fonts/AirbnbCereal_W_Bd.otf',
   '/fonts/Inter-VariableFont_opsz,wght.ttf',
   '/fonts/Montserrat-Regular.ttf',
-  '/icons/icon-16x16.webp',
-  '/icons/icon-32x32.webp',
-  '/icons/icon-48x48.webp',
-  '/icons/icon-64x64.webp',
-  '/icons/icon-72x72.webp',
-  '/icons/icon-76x76.webp',
-  '/icons/icon-96x96.webp',
-  '/icons/icon-114x114.webp',
-  '/icons/icon-120x120.webp',
-  '/icons/icon-128x128.webp',
-  '/icons/icon-144x144.webp',
-  '/icons/icon-152x152.webp',
-  '/icons/icon-180x180.webp',
-  '/icons/icon-192x192.webp',
-  '/icons/icon-196x196.webp',
-  '/icons/icon-228x228.webp',
-  '/icons/icon-256x256.webp',
-  '/icons/icon-384x384.webp',
-  '/icons/icon-512x512.webp',
-  '/apple-touch-icon.webp',
-  '/icon.avif',
-  '/icon.png',
-  '/icon.svg',
-  '/icon.webp',
-  '/favicon.ico',
+  '/icons/icon-16x16.webp', '/icons/icon-32x32.webp',
+  '/icons/icon-48x48.webp', '/icons/icon-64x64.webp',
+  '/icons/icon-72x72.webp', '/icons/icon-76x76.webp',
+  '/icons/icon-96x96.webp', '/icons/icon-114x114.webp',
+  '/icons/icon-120x120.webp', '/icons/icon-128x128.webp',
+  '/icons/icon-144x144.webp', '/icons/icon-152x152.webp',
+  '/icons/icon-180x180.webp', '/icons/icon-192x192.webp',
+  '/icons/icon-196x196.webp', '/icons/icon-228x228.webp',
+  '/icons/icon-256x256.webp', '/icons/icon-384x384.webp',
+  '/icons/icon-512x512.webp', '/apple-touch-icon.webp',
+  '/icon.avif', '/icon.png', '/icon.svg', '/icon.webp',
+  '/favicon.ico'
 ];
 
-// Install
+// -------------------- INSTALL --------------------
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches
-      .open(PRECACHE)
-      .then((cache) => {
-        // Map assets to their cache.add promises
-        const assetPromises = CORE_ASSETS.map((asset) => cache.add(asset));
-        return Promise.allSettled(assetPromises).then((results) => {
-          results.forEach((result, i) => {
-            if (result.status === 'rejected') {
-              console.error(`Failed to cache asset: ${CORE_ASSETS[i]}`, result.reason);
-            }
-          });
-        });
+    caches.open(PRECACHE)
+      .then(cache => {
+        const promises = CORE_ASSETS.map(asset =>
+          cache.add(asset).catch(err => console.error(`Failed to cache ${asset}:`, err))
+        );
+        return Promise.all(promises);
       })
       .then(() => self.skipWaiting())
   );
 });
 
-// Activate
+// -------------------- ACTIVATE --------------------
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(
-          keys.filter((key) => key !== PRECACHE && key !== RUNTIME).map((key) => caches.delete(key))
-        )
-      )
+    caches.keys()
+      .then(keys => Promise.all(
+        keys.filter(key => key !== PRECACHE && key !== RUNTIME)
+            .map(key => caches.delete(key))
+      ))
       .then(() => self.clients.claim())
   );
 });
 
-// Runtime cache pruning
+// -------------------- RUNTIME CACHE PRUNING --------------------
 async function pruneRuntimeCache() {
   const cache = await caches.open(RUNTIME);
   const requests = await cache.keys();
   const now = Date.now();
 
   let entries = await Promise.all(
-    requests.map(async (req) => {
+    requests.map(async req => {
       const res = await cache.match(req);
       const fetchedTime = res?.headers.get('SW-Fetched-Time');
       return { req, time: fetchedTime ? parseInt(fetchedTime) : 0 };
     })
   );
 
-  // Remove old entries by age
-  await Promise.all(
-    entries.map(async (entry) => {
-      if (now - entry.time > RUNTIME_MAX_AGE) {
-        await cache.delete(entry.req);
-        entry.deleted = true;
-      }
-    })
-  );
+  // Remove old entries
+  const toDelete = entries.filter(entry => now - entry.time > RUNTIME_MAX_AGE).map(e => e.req);
+  await Promise.all(toDelete.map(req => cache.delete(req)));
 
-  // Filter out deleted entries
-  entries = entries.filter((entry) => !entry.deleted);
-
-  // Remove excess entries beyond max entries
+  // Remove excess entries
+  entries = entries.filter(entry => now - entry.time <= RUNTIME_MAX_AGE);
   entries.sort((a, b) => a.time - b.time);
+
   while (entries.length > RUNTIME_MAX_ENTRIES) {
     const entry = entries.shift();
     if (entry) await cache.delete(entry.req);
   }
 }
 
-// Fetch handler
+// -------------------- FETCH HANDLER --------------------
 self.addEventListener('fetch', (event) => {
   const request = event.request;
   const url = new URL(request.url);
 
   if (request.method !== 'GET' || url.origin !== self.location.origin) return;
 
-  // Core assets: cache-first
+  // --- CORE ASSETS (cache-first) ---
   if (CORE_ASSETS.includes(url.pathname)) {
-    event.respondWith(
-      caches.match(request).then((cached) => {
-        const networkFetch = fetch(request)
-          .then((response) => {
-            if (response && response.status === 200) {
-              caches.open(PRECACHE).then((cache) => cache.put(request, response.clone()));
-            }
-            return response;
-          })
-          .catch((err) => {
-            console.error('Fetch failed for core asset:', request.url, err);
-            return cached || caches.match('/offline') || new Response('Service unavailable', { status: 503 });
-          });
-
-        return cached || networkFetch;
-      })
-    );
-  }
-  // Navigation requests: network-first, fallback offline
-  else if (request.mode === 'navigate') {
-    event.respondWith(
-      fetch(request).catch((err) => {
-        console.error('Navigation fetch failed:', request.url, err);
-        return caches.match('/offline') || new Response('Offline', { status: 503 });
-      })
-    );
-  }
-  // Other runtime requests: network-first, runtime cache
-  else {
-    event.respondWith(
-      caches.match(request).then(async (cached) => {
-        if (cached) return cached;
-
-        try {
-          const response = await fetch(request);
-          if (response && response.status === 200) {
-            const cloned = response.clone();
-            const headers = new Headers(cloned.headers);
-            headers.set('SW-Fetched-Time', Date.now().toString());
-            const modifiedResponse = new Response(await cloned.blob(), { headers });
-            const cache = await caches.open(RUNTIME);
-            await cache.put(request, modifiedResponse);
-            await pruneRuntimeCache();
-          }
-          return response;
-        } catch (err) {
-          console.error('Runtime fetch failed:', request.url, err);
-          return caches.match('/offline') || new Response('Service unavailable', { status: 503 });
+    event.respondWith((async () => {
+      const cached = await caches.match(request);
+      try {
+        const response = await fetch(request);
+        if (response && response.status === 200) {
+          const cache = await caches.open(PRECACHE);
+          cache.put(request, response.clone());
         }
-      })
-    );
+        return cached || response;
+      } catch {
+        return cached || await caches.match('/offline') || new Response('Service unavailable', { status: 503 });
+      }
+    })());
+    return;
   }
+
+  // --- NAVIGATION (network-first with offline fallback) ---
+  if (request.mode === 'navigate') {
+    event.respondWith((async () => {
+      try {
+        return await fetch(request);
+      } catch (err) {
+        console.error('Navigation fetch failed:', request.url, err);
+        return await caches.match('/offline') || new Response('Offline', { status: 503 });
+      }
+    })());
+    return;
+  }
+
+  // --- OTHER RUNTIME REQUESTS (network-first + runtime cache) ---
+  event.respondWith((async () => {
+    try {
+      const response = await fetch(request);
+      if (response && response.status === 200) {
+        const cloned = response.clone();
+        const headers = new Headers(cloned.headers);
+        headers.set('SW-Fetched-Time', Date.now().toString());
+        const modifiedResponse = new Response(await cloned.blob(), { headers });
+        const cache = await caches.open(RUNTIME);
+        await cache.put(request, modifiedResponse);
+        await pruneRuntimeCache();
+      }
+      return response;
+    } catch (err) {
+      console.error('Runtime fetch failed:', request.url, err);
+      const cached = await caches.match(request);
+      return cached || await caches.match('/offline') || new Response('Service unavailable', { status: 503 });
+    }
+  })());
 });
 
-// Skip waiting via client message
+// -------------------- SKIP WAITING --------------------
 self.addEventListener('message', (event) => {
   if (event.data?.type === 'SKIP_WAITING') self.skipWaiting();
 });

--- a/app/public/service-worker.js
+++ b/app/public/service-worker.js
@@ -43,7 +43,17 @@ self.addEventListener('install', (event) => {
   event.waitUntil(
     caches
       .open(PRECACHE)
-      .then((cache) => Promise.allSettled(CORE_ASSETS.map((asset) => cache.add(asset))))
+      .then((cache) => {
+        // Map assets to their cache.add promises
+        const assetPromises = CORE_ASSETS.map((asset) => cache.add(asset));
+        return Promise.allSettled(assetPromises).then((results) => {
+          results.forEach((result, i) => {
+            if (result.status === 'rejected') {
+              console.error(`Failed to cache asset: ${CORE_ASSETS[i]}`, result.reason);
+            }
+          });
+        });
+      })
       .then(() => self.skipWaiting())
   );
 });


### PR DESCRIPTION
This pull request refactors and improves the service worker in `app/public/service-worker.js` to make caching and offline support more robust and reliable. The main changes focus on error handling, cache management, and clearer separation of caching strategies for different types of requests.

**Caching and fetch strategy improvements:**

* The install event now uses `Promise.allSettled` to cache core assets, ensuring that failures in caching individual assets do not block the entire installation process.
* The fetch handler is restructured for clarity and reliability:  
  - Core assets use a cache-first strategy, with improved error handling and fallback to an offline page or a 503 response if both network and cache fail.
  - Navigation requests use a network-first strategy, falling back to the offline page on failure.
  - Other runtime requests use a network-first approach, with successful responses being cached and cache pruning triggered; failures fall back to the offline page or a 503 response.

**Cache management enhancements:**

* The runtime cache pruning logic is refactored to use asynchronous operations and better tracks which entries are deleted, ensuring only valid entries remain and the cache does not exceed age or size limits.

**General improvements:**

* Improved error logging for fetch failures and more robust fallback handling throughout the service worker.
* Minor code cleanups, such as optional chaining in message event handling.